### PR TITLE
Gmt5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ src/grad2vs30
 src/insert_grd
 src/smooth
 **/.gmtcommands4
+**/gmt.history

--- a/Australia/Makefile
+++ b/Australia/Makefile
@@ -73,7 +73,7 @@ aus.grd : aus_$(RES)c.grd
 
 ifeq ($(IS_FINER),true)
 aus_$(RES)c.grd : $(AUS_GRD_FILE)
-	grdsample -Ql0.1 -I$(RES)c -fg $< -G$@
+	grdsample -nl+t0.1 -I$(RES)s -fg $< -G$@
 else
 aus_$(RES)c.grd : $(AUS_GRD_FILE)
 	cp $< $@
@@ -95,7 +95,7 @@ plot_raw_map : aus_raw.png
 # Plot the weights:
  
 weights.png : weights.grd
-	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba4dg2d/a2eg2dWSen -K > weights.ps
+	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba10f5eWSn -K > weights.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> weights.ps
 	pscoast -JM12 -R$(AUS_REGION) -Df -O -N1 -N2 -W >> weights.ps
 	convert -trim -rotate 90 -density 300x300 weights.ps weights.png
@@ -109,7 +109,7 @@ AUS_REG_YMAX = $(shell echo $(AUS_YMAX) + $(ONE) | bc)
 AUS_REG = $(AUS_REG_XMIN)/$(AUS_REG_XMAX)/$(AUS_REG_YMIN)/$(AUS_REG_YMAX)
  
 aus.png : aus_region.grd
-	grdimage $< -JM12 -C$(VS30_CPT) -Ba6d/a4eWSen -K > aus_region.ps
+	grdimage $< -JM12 -C$(VS30_CPT) -Ba10f5eWSn -K > aus_region.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> aus_region.ps
 	pscoast -JM12 -R$(AUS_REG) -O -Df -N1 -N2 -W >> aus_region.ps
 	convert -trim -density 300x300 -rotate 90 aus_region.ps aus_region.png
@@ -120,7 +120,7 @@ aus_region.grd : ../$(OUTGRD)
 # Plot the raw geology map
 
 aus_raw.png : $(AUS_GRD_FILE)
-	grdimage $< -JM12 -C$(VS30_CPT) -Ba4d/a2eWSen -K > aus_raw.ps
+	grdimage $< -JM12 -C$(VS30_CPT) -Ba10f5eWSn -K > aus_raw.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> aus_raw.ps
 	pscoast -JM12 -R$(AUS_REGION) -O -Df -N1 -N2 -W >> aus_raw.ps
 	convert -trim -rotate 90 -density 300x300 aus_raw.ps aus_raw.png

--- a/California/Makefile
+++ b/California/Makefile
@@ -114,7 +114,7 @@ vs30_ext_h2o600.grd : vs30_$(RES)c_ext.grd landmask.grd
 	grdmath vs30_$(RES)c_ext.grd landmask.grd 600 MUL AND = $@
 
 landmask.grd : 
-	grdlandmask -V -R$(CA_EXT_REGION) -I$(RES)c -G$@ -Df -N1/0/0/0/0
+	grdlandmask -V -R$(CA_EXT_REGION) -I$(RES)s -G$@ -Df -N1/0/0/0/0
 
 #
 # Paste a 1-degree chunk of NaNs to the top of the map:
@@ -123,7 +123,7 @@ vs30_$(RES)c_ext.grd : vs30_$(RES)c.grd top.grd
 	grdpaste vs30_$(RES)c.grd top.grd -G$@
 
 top.grd : 
-	grdmath -R-124.475/-114.025/41.9916666667/43.0 -I$(RES)c 0 0 NAN = top.grd
+	grdmath -R-124.475/-114.025/41.9916666667/43.0 -I$(RES)s 0 0 NAN = top.grd
 
 #
 # Rescale to proper resolution. If the output is coarser than the
@@ -133,10 +133,10 @@ top.grd :
 
 ifeq ($(IS_COARSER),true)
 vs30_$(RES)c.grd : Vs30_Cal_hyb_KT_ml_20c_fill_Ql.grd
-	grdfilter -I$(RES)c -D0 -Fg0.016 $< -G$@
+	grdfilter -I$(RES)s -D0 -Fg0.016 $< -G$@
 else
 vs30_$(RES)c.grd : Vs30_Cal_hyb_KT_ml_20c_fill_Ql.grd
-	grdsample -Ql0.1 -I$(RES)c -fg $< -G$@
+	grdsample -nl+t0.1 -I$(RES)s -fg $< -G$@
 endif
 
 Vs30_Cal_hyb_KT_ml_20c_fill_Ql.grd :
@@ -163,7 +163,7 @@ plot_final_map_wus : wus.png
 # Plot the resampled base Vs30 map
 
 base.png : vs30_$(RES)c.grd
-	grdimage vs30_$(RES)c.grd -JM12 -C$(VS30_CPT) -Ba4d/a2eWSen -K > base.ps
+	grdimage vs30_$(RES)c.grd -JM12 -C$(VS30_CPT) -Ba2f1WSen -K > base.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> base.ps
 	pscoast -JM12 -R$(CA_BASE_REGION) -O -N1 -N2 -W >> base.ps
 	convert -rotate 90 base.ps base.png
@@ -171,7 +171,7 @@ base.png : vs30_$(RES)c.grd
 # Plot the landmask with CA Vs30s inserted:
  
 landmask.png : vs30_ext_h2o600.grd
-	grdimage vs30_ext_h2o600.grd -JM12 -C$(VS30_CPT) -Ba4d/a2eWSen -K > landmask.ps
+	grdimage vs30_ext_h2o600.grd -JM12 -C$(VS30_CPT) -Ba2f1WSen -K > landmask.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> landmask.ps
 	pscoast -JM12 -R$(CA_EXT_REGION) -O -N1 -N2 -W >> landmask.ps
 	convert -rotate 90 landmask.ps landmask.png
@@ -179,14 +179,14 @@ landmask.png : vs30_ext_h2o600.grd
 # Plot the clipping mask:
 
 clipmask.png : mask.grd
-	grdimage mask.grd -JM12 -C$(WEIGHTS_CPT) -Ba4d/a2eWSen -K > clipmask.ps
+	grdimage mask.grd -JM12 -C$(WEIGHTS_CPT) -Ba2f1WSen -K > clipmask.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O >> clipmask.ps
 	convert -rotate 90 clipmask.ps clipmask.png
  
 # Plot the smoothed clipping mask:
 
 landmask_smooth.png : mask_smooth.grd
-	grdimage mask_smooth.grd -JM12 -C$(WEIGHTS_CPT) -Ba4d/a2eWSen -K > landmask_smooth.ps
+	grdimage mask_smooth.grd -JM12 -C$(WEIGHTS_CPT) -Ba2f1WSen -K > landmask_smooth.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> landmask_smooth.ps
 	pscoast -JM12 -R$(CA_EXT_REGION) -O -N1 -N2 -W >> landmask_smooth.ps
 	convert -rotate 90 landmask_smooth.ps landmask_smooth.png
@@ -194,7 +194,7 @@ landmask_smooth.png : mask_smooth.grd
 # Plot the rescaled clipping mask.
 
 clipmask_2.png : mask_2.grd
-	grdimage mask_2.grd -JM12 -C$(WEIGHTS_CPT) -Ba4d/a2eWSen -K > clipmask_2.ps
+	grdimage mask_2.grd -JM12 -C$(WEIGHTS_CPT) -Ba2f1WSen -K > clipmask_2.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> clipmask_2.ps
 	pscoast -JM12 -R$(CA_EXT_REGION) -O -N1 -N2 -W >> clipmask_2.ps
 	convert -rotate 90 clipmask_2.ps clipmask_2.png
@@ -202,7 +202,7 @@ clipmask_2.png : mask_2.grd
 # Plot the weights:
 
 weights.png : weights.grd
-	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba4dg2d/a2eg2dWSen -K > weights.ps
+	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba2f1WSen -K > weights.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> weights.ps     
 	pscoast -JM12 -R$(CA_EXT_REGION) -O -N1 -N2 -W >> weights.ps
 	convert -rotate 90 weights.ps weights.png
@@ -210,7 +210,7 @@ weights.png : weights.grd
 # Plot the new Vs30 map in a cut out map of the western US
  
 wus.png : wus_vs30.grd
-	grdimage wus_vs30.grd -JM12 -C$(VS30_CPT) -Ba4d/a2eWSen -K > wus.ps
+	grdimage wus_vs30.grd -JM12 -C$(VS30_CPT) -Ba2f1WSen -K > wus.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> wus.ps
 	pscoast -JM12 -R$(WUS_REGION) -O -N1 -N2 -W >> wus.ps
 	convert -rotate 90 wus.ps wus.png

--- a/Japan/Makefile
+++ b/Japan/Makefile
@@ -72,7 +72,7 @@ weights.grd : japan.grd
 # Make the raster file into a GMT grd
 #
 japan.grd : shape/japan_$(RES)c.bil
-	xyz2grd -R$(JP_REGION) -I$(RES)c -Zf $< -G$@
+	xyz2grd -R$(JP_REGION) -I$(RES)s -ZTLf $< -G$@
 #
 # Convert shape file into a raster file
 #
@@ -101,7 +101,7 @@ plot_raw_map : japan_raw.png
 # Plot the weights:
  
 weights.png : weights.grd
-	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba4dg2d/a2eg2dWSen -K > weights.ps
+	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba4f2eSWn -K > weights.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> weights.ps
 	pscoast -JM12 -R$(JP_REGION) -Df -O -N1 -N2 -W >> weights.ps
 	convert -trim -rotate 90 -density 300x300 weights.ps weights.png
@@ -109,7 +109,7 @@ weights.png : weights.grd
 # Plot the new Vs30 map:
  
 japan_region.png : japan_region.grd
-	grdimage $< -JM12 -C$(VS30_CPT) -Ba6d/a4eWSen -K > japan_region.ps
+	grdimage $< -JM12 -C$(VS30_CPT) -Ba4f2eSWn -K > japan_region.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> japan_region.ps
 	pscoast -JM12 -R$(JP_REGION) -O -Df -N1 -N2 -W >> japan_region.ps
 	convert -trim -density 300x300 -rotate 90 japan_region.ps japan_region.png
@@ -120,7 +120,7 @@ japan_region.grd : ../$(OUTGRD)
 # Plot the raw geology map using its own scale.
 
 japan_raw.png : japan.grd
-	grdimage $< -JM12 -C$(VS30_CPT) -Ba4d/a2eWSen -K > japan_raw.ps
+	grdimage $< -JM12 -C$(VS30_CPT) -Ba4f2eSWn -K > japan_raw.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O >> japan_raw.ps
 	convert -trim -rotate 90 -density 300x300 japan_raw.ps japan_raw.png
 

--- a/NZ/Makefile
+++ b/NZ/Makefile
@@ -99,7 +99,7 @@ plot_raw_map : newzealand_raw.png
 # Plot the weights:
  
 weights.png : weights.grd
-	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba4dg2d/a2eg2dWSen -K > weights.ps
+	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba4f2eWSn -K > weights.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> weights.ps
 	pscoast -JM12 -R$(NZ_REGION) -Df -O -N1 -N2 -W >> weights.ps
 	convert -trim -rotate 90 -density 300x300 weights.ps weights.png
@@ -113,7 +113,7 @@ NZ_REG_YMAX = $(shell echo $(NZ_YMAX) + $(ONE) | bc)
 NZ_REG = $(NZ_REG_XMIN)/$(NZ_REG_XMAX)/$(NZ_REG_YMIN)/$(NZ_REG_YMAX)
  
 newzealand.png : newzealand_region.grd
-	grdimage $< -JM12 -C$(VS30_CPT) -Ba6d/a4eWSen -K > newzealand_region.ps
+	grdimage $< -JM12 -C$(VS30_CPT) -Ba4f2eWSn -K > newzealand_region.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> newzealand_region.ps
 	pscoast -JM12 -R$(NZ_REG) -O -Df -N1 -N2 -W >> newzealand_region.ps
 	convert -trim -density 300x300 -rotate 90 newzealand_region.ps newzealand_region.png
@@ -124,7 +124,7 @@ newzealand_region.grd : ../$(OUTGRD)
 # Plot the raw geology map
 
 newzealand_raw.png : vs30_nz_gmt4.grd
-	grdimage $< -JM12 -C$(VS30_CPT) -Ba4d/a2eWSen -K > newzealand_raw.ps
+	grdimage $< -JM12 -C$(VS30_CPT) -Ba4f2eWSn -K > newzealand_raw.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> newzealand_raw.ps
 	pscoast -JM12 -R$(NZ_REGION) -O -Df -N1 -N2 -W >> newzealand_raw.ps
 	convert -trim -rotate 90 -density 300x300 newzealand_raw.ps newzealand_raw.png

--- a/NZ/Makefile
+++ b/NZ/Makefile
@@ -74,7 +74,7 @@ newzealand.grd : nz_$(RES)c.grd
 
 ifeq ($(IS_FINER),true)
 nz_$(RES)c.grd : vs30_nz_gmt4.grd
-	grdsample -Ql0.1 -I$(RES)c -fg $< -G$@
+	grdsample -nl+t0.1 -I$(RES)s -fg $< -G$@
 else
 nz_$(RES)c.grd : vs30_nz_gmt4.grd
 	cp $< $@

--- a/PNW/Makefile
+++ b/PNW/Makefile
@@ -107,10 +107,10 @@ mask.grd : $(MYEXT)_$(RES)c.grd
 #
 ifeq ($(IS_COARSER),true)
 $(MYEXT)_$(RES)c.grd : waor_ext.grd
-	grdfilter -I$(RES)c -R$(PNW_EXT_REGION) -D0 -Fm0.016 waor_ext.grd -G$(MYEXT)_$(RES)c.grd
+	grdfilter -I$(RES)s -R$(PNW_EXT_REGION) -D0 -Fm0.016 waor_ext.grd -G$(MYEXT)_$(RES)c.grd
 else
 $(MYEXT)_$(RES)c.grd : waor_ext.grd
-	grdsample -Qn -I$(RES)c -fg -R$(PNW_EXT_REGION) waor_ext.grd -G$(MYEXT)_$(RES)c.grd
+	grdsample -Qn -I$(RES)s -fg -R$(PNW_EXT_REGION) waor_ext.grd -G$(MYEXT)_$(RES)c.grd
 endif
 
 #
@@ -125,16 +125,16 @@ waor_ext.grd : orwash20c_600.grd north.grd south.grd west.grd east.grd
 	$(RM) tmp.grd
 
 north.grd :
-	grdmath -R-125.144158614/-116.462158614/49.083401663/50.083401663 -I20c $(WATER) = north.grd
+	grdmath -R-125.144158614/-116.462158614/49.083401663/50.083401663 -I20s $(WATER) = north.grd
 
 south.grd :
-	grdmath -R-125.144158614/-116.462158614/40.995401663/41.995401663 -I20c $(WATER) = south.grd
+	grdmath -R-125.144158614/-116.462158614/40.995401663/41.995401663 -I20s $(WATER) = south.grd
 
 west.grd :
-	grdmath -R-126.144158614/-125.144158614/40.995401663/50.083401663 -I20c $(WATER) = west.grd
+	grdmath -R-126.144158614/-125.144158614/40.995401663/50.083401663 -I20s $(WATER) = west.grd
 
 east.grd :
-	grdmath -R-116.462158614/-115.462158614/40.995401663/50.083401663 -I20c $(WATER) = east.grd
+	grdmath -R-116.462158614/-115.462158614/40.995401663/50.083401663 -I20s $(WATER) = east.grd
 
 #
 # This grid uses NaN as water and unknown gelolgy, but we want 600, so 
@@ -177,7 +177,7 @@ base.png : orwash20c.grd
 # Plot the extended Vs30 map:
 
 ext.png : $(MYEXT)_$(RES)c.grd 
-	grdimage $< -JM12 -C$(VS30_CPT) -Ba4d/a2eWSen -K > ext.ps
+	grdimage $< -JM12 -C$(VS30_CPT) -Ba2f1WSen -K > ext.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> ext.ps
 	pscoast -JM12 -R$(PNW_EXT_REGION) -Df -O -N1 -N2 -W >> ext.ps
 	convert -trim -density 300x300 -rotate 90 ext.ps ext.png
@@ -185,7 +185,7 @@ ext.png : $(MYEXT)_$(RES)c.grd
 # Plot the clipping mask:
  
 clipmask.png : mask.grd
-	grdimage mask.grd -JM12 -C$(WEIGHTS_CPT) -Ba4d/a2eWSen -K > clipmask.ps
+	grdimage mask.grd -JM12 -C$(WEIGHTS_CPT) -Ba2f1WSen -K > clipmask.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> clipmask.ps
 	pscoast -JM12 -R$(PNW_EXT_REGION) -Df -O -N1 -N2 -W >> clipmask.ps
 	convert -trim -rotate 90 clipmask.ps clipmask.png
@@ -193,7 +193,7 @@ clipmask.png : mask.grd
 # Plot the smoothed clipping mask:
  
 clipmask_smooth.png : mask_smooth.grd
-	grdimage mask_smooth.grd -JM12 -C$(WEIGHTS_CPT) -Ba4d/a2eWSen -K > clipmask_smooth.ps
+	grdimage mask_smooth.grd -JM12 -C$(WEIGHTS_CPT) -Ba2f1WSen -K > clipmask_smooth.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> clipmask_smooth.ps
 	pscoast -JM12 -R$(PNW_EXT_REGION) -Df -O -N1 -N2 -W >> clipmask_smooth.ps
 	convert -trim -rotate 90 clipmask_smooth.ps clipmask_smooth.png
@@ -201,7 +201,7 @@ clipmask_smooth.png : mask_smooth.grd
 # Plot the rescaled clipping mask.
  
 clipmask_2.png : mask_2.grd
-	grdimage mask_2.grd -JM12 -C$(WEIGHTS_CPT) -Ba4d/a2eWSen -K > clipmask_2.ps
+	grdimage mask_2.grd -JM12 -C$(WEIGHTS_CPT) -Ba2f1WSen -K > clipmask_2.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> clipmask_2.ps
 	pscoast -JM12 -R$(PNW_EXT_REGION) -Df -O -N1 -N2 -W >> clipmask_2.ps
 	convert -trim -rotate 90 clipmask_2.ps clipmask_2.png
@@ -209,7 +209,7 @@ clipmask_2.png : mask_2.grd
 # Plot the weights:
  
 weights.png : weights.grd
-	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba4dg2d/a2eg2dWSen -K > weights.ps
+	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba2f1WSen -K > weights.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> weights.ps     
 	pscoast -JM12 -R$(PNW_EXT_REGION) -Df -O -N1 -N2 -W >> weights.ps
 	convert -trim -rotate 90 weights.ps weights.png
@@ -217,7 +217,7 @@ weights.png : weights.grd
 # Plot the new Vs30 map in the western US region:
  
 wus.png : wus_vs30.grd
-	grdimage wus_vs30.grd -JM12 -C$(VS30_CPT) -Ba6d/a4eWSen -K > wus.ps
+	grdimage wus_vs30.grd -JM12 -C$(VS30_CPT) -Ba4f2WSen -K > wus.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> wus.ps
 	pscoast -JM12 -R$(WUS_REGION) -O -Df -N1 -N2 -W >> wus.ps
 	convert -trim -density 300x300 -rotate 90 wus.ps wus.png
@@ -228,7 +228,7 @@ wus_vs30.grd : ../$(OUTGRD)
 # Plot the new Vs30 map at the original scale:
  
 waor.png : waor_embedded.grd
-	grdimage $< -JM12 -C$(VS30_CPT) -Ba6d/a4eWSen -K > waor.ps
+	grdimage $< -JM12 -C$(VS30_CPT) -Ba2f1WSen -K > waor.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> waor.ps
 	pscoast -JM12 -R$(PNW_BASE_REGION) -O -Df -N1 -N2 -W >> waor.ps
 	convert -trim -density 300x300 -rotate 90 waor.ps waor.png

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ one is http://curl.haxx.se.
 
 + **GMT/NetCDF** -- The Generic Mapping Tools package must be installed, and
 NetCDF with it. GMT can be downloaded from: http://gmt.soest.hawaii.edu/.
-Get version 4 -- this software hasn't been tested with version 5. Make
-sure to install the full-resolution shoreline database.
+The latest stable version -- 5.4.4 -- has been tested. Note that GMT version 
+4 will no longer work. Make sure to install the full-resolution shoreline database.
 
 
 + The **GDAL (Geospatial Data Abstraction Library)** package must be available.
@@ -63,6 +63,12 @@ You will need to set a path to the gdal binaries in Constants.mk.
 In particular, the programs gdal_rasterize and gdal_translate are used
 herein. GDAL can be installed by most package managers, but they often
 have very old versions. The software can also be found at www.gdal.org.
+
+
++ **ImageMagick** must be installed in order to view the plots created to spot-check
+the grid creation (using the command "convert"). This code is tested with version 7.0.8-7. 
+Please make sure to follow the installation instructions to ensure your path points 
+to the correct location. 
 
 
 + If you have runtime problems with the C programs ("smooth", "insert_grd",

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ one is http://curl.haxx.se.
 
 + **GMT/NetCDF** -- The Generic Mapping Tools package must be installed, and
 NetCDF with it. GMT can be downloaded from: http://gmt.soest.hawaii.edu/.
-The latest stable version -- 5.4.4 -- has been tested. Note that GMT version 
+The latest stable version -- 5.4.4 -- should be downloaded. **Note** that GMT version 
 4 will no longer work. Make sure to install the full-resolution shoreline database.
 
 

--- a/Slope/Makefile
+++ b/Slope/Makefile
@@ -39,7 +39,7 @@ veryclean : clean
 # newer versions of GMT):
 #
 global_grad.grd : gmted_global.grd
-	grdgradient gmted_global.grd -Lg -M -D -Sglobal_grad.grd -Gjunk.grd -V
+	grdgradient gmted_global.grd -n+bg -fg -D -Sglobal_grad.grd -Gjunk.grd -V
 	$(RM) junk.grd
 
 #
@@ -47,7 +47,7 @@ global_grad.grd : gmted_global.grd
 # node registration:
 #
 gmted_global.grd : elev/gmted_global.bil
-	xyz2grd -Zh -F -R$(GLOBAL_REGION) -I$(RES)c elev/gmted_global.bil \
+	xyz2grd -ZTLh -r -R$(GLOBAL_REGION) -I$(RES)s elev/gmted_global.bil \
                 -Ggmted_global_pixel.grd
 	grdsample gmted_global_pixel.grd -Ggmted_global.grd -T -fg
 	$(RM) gmted_global_pixel.grd
@@ -78,7 +78,7 @@ elev/md$(GRES)_grd.zip :
 # Create the landmask:
 #
 global_landmask.grd : 
-	grdlandmask -V -R$(GLOBAL_REGION) -I$(RES)c -Gglobal_landmask.grd -Df
+	grdlandmask -V -R$(GLOBAL_REGION) -I$(RES)s -Gglobal_landmask.grd -Df
 
 #
 # Smooth the craton file
@@ -92,8 +92,8 @@ cratons_smooth.grd : cratons.grd ../src/smooth
 # node registration; use -Qn to keep everything at 0 and 1:
 #
 cratons.grd : cratons.bil
-	xyz2grd -R$(GLOBAL_REGION) -I$(RES)c -Zc -F cratons.bil -Gcratons_pixel.grd
-	grdsample cratons_pixel.grd -Gcratons.grd -T -fg -Qn
+	xyz2grd -R$(GLOBAL_REGION) -I$(RES)s -ZTLc -r cratons.bil -Gcratons_pixel.grd
+	grdsample cratons_pixel.grd -Gcratons.grd -T -fg -nn
 	$(RM) cratons_pixel.grd
 
 #

--- a/Taiwan/Makefile
+++ b/Taiwan/Makefile
@@ -95,7 +95,7 @@ plot_raw_map : taiwan_raw.png
 # Plot the weights:
  
 weights.png : weights.grd
-	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba4dg2d/a2eg2dWSen -K > weights.ps
+	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba1WSen -K > weights.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> weights.ps
 	pscoast -JM12 -R$(TW_REGION) -Df -O -N1 -N2 -W >> weights.ps
 	convert -trim -rotate 90 -density 300x300 weights.ps weights.png
@@ -109,7 +109,7 @@ TW_REG_YMAX = $(shell echo $(TW_YMAX) + $(ONE) | bc)
 TW_REG = $(TW_REG_XMIN)/$(TW_REG_XMAX)/$(TW_REG_YMIN)/$(TW_REG_YMAX)
  
 taiwan.png : taiwan_region.grd
-	grdimage $< -JM12 -C$(VS30_CPT) -Ba6d/a4eWSen -K > taiwan_region.ps
+	grdimage $< -JM12 -C$(VS30_CPT) -Ba1WSen -K > taiwan_region.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> taiwan_region.ps
 	pscoast -JM12 -R$(TW_REG) -O -Df -N1 -N2 -W >> taiwan_region.ps
 	convert -trim -density 300x300 -rotate 90 taiwan_region.ps taiwan_region.png
@@ -120,7 +120,7 @@ taiwan_region.grd : ../$(OUTGRD)
 # Plot the raw geology map
 
 taiwan_raw.png : $(TW_GRD_FILE)
-	grdimage $< -JM12 -C$(VS30_CPT) -Ba4d/a2eWSen -K > taiwan_raw.ps
+	grdimage $< -JM12 -C$(VS30_CPT) -Ba1WSen -K > taiwan_raw.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> taiwan_raw.ps
 	pscoast -JM12 -R$(TW_REGION) -O -Df -N1 -N2 -W >> taiwan_raw.ps
 	convert -trim -rotate 90 -density 300x300 taiwan_raw.ps taiwan_raw.png

--- a/Utah/Makefile
+++ b/Utah/Makefile
@@ -93,23 +93,23 @@ ut_ext.grd : $(MYEXT)_$(RES)c.grd north.grd south.grd west.grd east.grd
 	$(RM) tmp.grd
 
 north.grd :
-	grdmath -R-114.2/-108.9/42.4/42.9 -I$(RES)c 0 = north.grd
+	grdmath -R-114.2/-108.9/42.4/42.9 -I$(RES)s 0 = north.grd
 
 south.grd :
-	grdmath -R-114.2/-108.9/36.3/36.8 -I$(RES)c 0 = south.grd
+	grdmath -R-114.2/-108.9/36.3/36.8 -I$(RES)s 0 = south.grd
 
 west.grd :
-	grdmath -R-114.7/-114.2/36.3/42.9 -I$(RES)c 0 = west.grd
+	grdmath -R-114.7/-114.2/36.3/42.9 -I$(RES)s 0 = west.grd
 
 east.grd :
-	grdmath -R-108.9/-108.2/36.3/42.9 -I$(RES)c 0 = east.grd
+	grdmath -R-108.9/-108.2/36.3/42.9 -I$(RES)s 0 = east.grd
 
 #
 # Rescale to 30-second resolution and shift the map to make it co-register
 # with the global grid.
 #
 $(MYEXT)_$(RES)c.grd : utah6_geology_60s.grd
-	grdsample -Ql0.1 -I$(RES)c -fg -R$(UTAH_BASE_REGION) $< -G$@
+	grdsample -nl+t0.1 -I$(RES)s -fg -R$(UTAH_BASE_REGION) $< -G$@
 
 utah6_geology_60s.grd :
 	echo "Utah grid file utah6_geology_60s.grd must be supplied."
@@ -133,7 +133,7 @@ plot_raw_map : utah.png
 # Plot the base Vs30 Map:
  
 base.png : $(MYEXT)_$(RES)c.grd
-	grdimage $(MYEXT)_$(RES)c.grd -JM12 -C$(VS30_CPT) -Ba4d/a2eWSen -K > base.ps
+	grdimage $(MYEXT)_$(RES)c.grd -JM12 -C$(VS30_CPT) -Ba1WSen -K > base.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> base.ps
 	pscoast -JM12 -R$(UTAH_BASE_REGION) -Df -O -N1 -N2 -W >> base.ps
 	convert -trim -density 300x300 -rotate 90 base.ps base.png
@@ -141,7 +141,7 @@ base.png : $(MYEXT)_$(RES)c.grd
 # Plot the clipping mask:
  
 clipmask.png : mask.grd
-	grdimage mask.grd -JM12 -C$(WEIGHTS_CPT) -Ba4d/a2eWSen -K > clipmask.ps
+	grdimage mask.grd -JM12 -C$(WEIGHTS_CPT) -Ba1WSen -K > clipmask.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> clipmask.ps
 	pscoast -JM12 -R$(UTAH_EXT_REGION) -Df -O -N1 -N2 -W >> clipmask.ps
 	convert -trim -rotate 90 clipmask.ps clipmask.png
@@ -149,7 +149,7 @@ clipmask.png : mask.grd
 # Plot the smoothed clipping mask:
  
 mask_smooth.png : mask_smooth.grd
-	grdimage mask_smooth.grd -JM12 -C$(WEIGHTS_CPT) -Ba4d/a2eWSen -K > mask_smooth.ps
+	grdimage mask_smooth.grd -JM12 -C$(WEIGHTS_CPT) -Ba1WSen -K > mask_smooth.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> mask_smooth.ps
 	pscoast -JM12 -R$(UTAH_EXT_REGION) -Df -O -N1 -N2 -W >> mask_smooth.ps
 	convert -trim -rotate 90 mask_smooth.ps mask_smooth.png
@@ -157,7 +157,7 @@ mask_smooth.png : mask_smooth.grd
 # Plot the weights:
  
 weights.png : weights.grd
-	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba4dg2d/a2eg2dWSen -K > weights.ps
+	grdimage weights.grd -C$(WEIGHTS_CPT) -JM12 -Ba1WSen -K > weights.ps
 	psscale -D14/4.3/9/0.5 -L -C$(WEIGHTS_CPT) -O -K >> weights.ps     
 	pscoast -JM12 -R$(UTAH_EXT_REGION) -Df -O -N1 -N2 -W >> weights.ps
 	convert -trim -rotate 90 weights.ps weights.png
@@ -165,7 +165,7 @@ weights.png : weights.grd
 # Plot the new Vs30 map:
  
 wus.png : wus_vs30.grd
-	grdimage wus_vs30.grd -JM12 -C$(VS30_CPT) -Ba6d/a4eWSen -K > wus.ps
+	grdimage wus_vs30.grd -JM12 -C$(VS30_CPT) -Ba4f2WSen -K > wus.ps
 	psscale -D14/4.3/9/0.5 -L -C$(VS30_CPT) -O -K >> wus.ps
 	pscoast -JM12 -R$(BIG_WUS_REGION) -O -Df -N1 -N2 -W >> wus.ps
 	convert -trim -density 300x300 -rotate 90 wus.ps wus.png
@@ -176,7 +176,7 @@ wus_vs30.grd : ../$(OUTGRD)
 # Plot the raw geology map using its own scale.
 
 utah.png : utah6_geology_60s.grd
-	grdimage utah6_geology_60s.grd -JM12 -C../Misc/utah.cpt -Ba4d/a2eWSen -K > utah.ps
+	grdimage utah6_geology_60s.grd -JM12 -C../Misc/utah.cpt -Ba1WSen -K > utah.ps
 	psscale -D14/4.3/9/0.5 -L -C../Misc/utah.cpt -O -K >> utah.ps
 	pscoast -R-114.2365/-108.877/36.7625/42.4865 -JM12 -N1 -N2 -W -Df -O >> utah.ps
 	convert -rotate 90 -density 300x300 utah.ps utah.png

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-include ../Constants.mk
+include ~/.vs30/Constants.mk
 
 LIBPATH = -L$(GMTLIB) -L$(CDFLIB)
 INCPATH = -I$(GMTINC) -I$(CDFINC)


### PR DESCRIPTION
Code should now be compatible with GMT 5. Note there are some various warnings on grdcut and a few other GMT commands. I think this happens when the region's lat/lon coordinates have more than 3 decimal places, but that's just a hunch.